### PR TITLE
Update for django 3.x

### DIFF
--- a/defender/models.py
+++ b/defender/models.py
@@ -1,7 +1,13 @@
 from __future__ import unicode_literals
 
+import django
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+if django.VERSION[0] < 3:
+    from django.utils.encoding import python_2_unicode_compatible
+else:
+    # noop stub
+    def python_2_unicode_compatible(cls):
+        return cls
 
 
 @python_2_unicode_compatible

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     include_package_data=True,
     packages=find_packages(),
     package_data=get_package_data("defender"),
-    install_requires=["Django>=1.8,<2.3,>=3.0", "redis>=2.10.3,<3.3,>=3.4"],
+    install_requires=["Django<=3.1", "redis<=3.5"],
     tests_require=[
         "mock",
         "mockredispy>=2.9.0.11,<3.0",

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     include_package_data=True,
     packages=find_packages(),
     package_data=get_package_data("defender"),
-    install_requires=["Django>=1.8,<2.3", "redis>=2.10.3,<3.3"],
+    install_requires=["Django>=1.8,<2.3,>=3.0", "redis>=2.10.3,<3.3,>=3.4"],
     tests_require=[
         "mock",
         "mockredispy>=2.9.0.11,<3.0",

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     include_package_data=True,
     packages=find_packages(),
     package_data=get_package_data("defender"),
-    install_requires=["Django<=3.1", "redis<=3.5"],
+    install_requires=["Django>=1.8,<=3.1", "redis<=3.5"],
     tests_require=[
         "mock",
         "mockredispy>=2.9.0.11,<3.0",


### PR DESCRIPTION
Updated to allow this app to work with Django 3.x by removing reference to python 2 specific code without breaking backwards compatibility (i.e. usable with Django < 2 with python 2.x).

- Django dependency in setup.py may need to be limited to <= 3.1
- Django-redis module updated to something more contemporary - don't know why it was previously limited but so far seems to work fine.

Currently testing this in a full async Django install (Nginx + daphne + websockets enabled), but tbh the site in question does not yet use a lot of the async capability; some are planned. The currently staged/beta app seems to work and passes all unittests.
