### PR TITLE
dynamic load celery

### DIFF
--- a/defender/tasks.py
+++ b/defender/tasks.py
@@ -1,12 +1,7 @@
 from .data import store_login_attempt
-
-# not sure how to get this to look better. ideally we want to dynamically
-# apply the celery decorator based on the USE_CELERY setting.
-
-from celery import shared_task
+from . import config
 
 
-@shared_task()
 def add_login_attempt_task(
     user_agent, ip_address, username, http_accept, path_info, login_valid
 ):
@@ -14,3 +9,7 @@ def add_login_attempt_task(
     store_login_attempt(
         user_agent, ip_address, username, http_accept, path_info, login_valid
     )
+
+if config.USE_CELERY:
+    from celery import shared_task
+    add_login_attempt_task = shared_task(add_login_attempt_task)


### PR DESCRIPTION
Using django-defender with any other project that uses `autodiscover_modules` tasks,  makes django-defender depend on celery.

To give you an example, I have a Django project with Huey (https://github.com/coleifer/huey) and I need this PR to use django-defender.

I think this solves the comment

> not sure how to get this to look better. ideally we want to dynamically apply the celery decorator based on the USE_CELERY setting.

