### PR TITLE
Fix Django-redis-cache version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -e .
 coverage
 mockredispy
-django-redis-cache
+django-redis-cache==2.1.1
 celery<5
 mock; python_version < '3.0'


### PR DESCRIPTION
The django-redis-cache version 2.1.3 is broken in pypi, let's roll back to 2.1.1 until it is fixed.