### PR TITLE
FIX: make password quote optional in the funciton signature

### DIFF
--- a/defender/connection.py
+++ b/defender/connection.py
@@ -46,7 +46,7 @@ def get_redis_connection():
         )
 
 
-def parse_redis_url(url, password_quote):
+def parse_redis_url(url, password_quote=None):
     """Parses a redis URL."""
 
     # create config with some sane defaults


### PR DESCRIPTION
The `password_quote` is treated as optional inside the function.
It shouldn't fail if not passed