### PR TITLE
Fix version.

### DIFF
--- a/defender/__init__.py
+++ b/defender/__init__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 7, 0)
+VERSION = (0, 8, 0)
 
 __version__ = ".".join((map(str, VERSION)))


### PR DESCRIPTION
The last tag is [v0.8.0](https://github.com/jazzband/django-defender/releases/tag/v0.8.0)
It missed in last release