### PR TITLE
Fix failing tests to work with Django (4.0) main dev branch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Changes
 =======
 
+Unreleased
+----------
+
+* Fix failing tests for Django main development branch (Django 4.0)
+
 0.9.0
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -397,7 +397,7 @@ There's sample ``BasicAuthenticationDefender`` class based on ``djangorestframew
    import base64
    import binascii
 
-   from django.utils.translation import ugettext_lazy as _
+   from django.utils.translation import gettext_lazy as _
 
    from rest_framework import HTTP_HEADER_ENCODING, exceptions
    from rest_framework.authentication import (

--- a/defender/config.py
+++ b/defender/config.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 
 def get_setting(variable, default=None):
@@ -61,7 +61,7 @@ except ValueError:  # pragma: no cover
 
 LOCKOUT_TEMPLATE = get_setting("DEFENDER_LOCKOUT_TEMPLATE")
 
-ERROR_MESSAGE = ugettext_lazy(
+ERROR_MESSAGE = gettext_lazy(
     "Please enter a correct username and password. "
     "Note that both fields are case-sensitive."
 )

--- a/defender/signals.py
+++ b/defender/signals.py
@@ -1,9 +1,9 @@
 from django.dispatch import Signal
 
-username_block = Signal(providing_args=["username"])
-username_unblock = Signal(providing_args=["username"])
-ip_block = Signal(providing_args=["ip_address"])
-ip_unblock = Signal(providing_args=["ip_address"])
+username_block = Signal()  # (providing_args=["username"])
+username_unblock = Signal()  # (providing_args=["username"])
+ip_block = Signal()  # (providing_args=["ip_address"])
+ip_unblock = Signal()  # (providing_args=["ip_address"])
 
 
 class BlockSignal:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    # list of supported Django/Python versioons:
+    # list of supported Django/Python versions:
     py{36,37,38,39,py3}-dj{22,31,32}
     py{38,39}-djmain
     py38-{lint,docs}


### PR DESCRIPTION
Fixes #184 

Tox tests are currently failing for `djmain` (Django 4.0) environment because of deprecated/removed items (see issue #184 for full details).  

This PR fixes those issues, by:
- replacing `ugettext_lazy()` with `gettext_lazy()` (for which it is an alias)
- removing the no longer supported `providing_args` argument when defining Signals.  

The PR also fixes a minor typo in the 'tox.ini` file

Note, the commented out `providing_args` were left in for reference, but can be completely removed if required.

