### PR TITLE
Fix for IP backdoor to DEFENDER_LOCK_OUT_BY_IP_AND_USERNAME

### DIFF
--- a/defender/tests.py
+++ b/defender/tests.py
@@ -719,6 +719,14 @@ class AccessAttemptTest(DefenderTestCase):
         response = self._login()
         self.assertContains(response, LOGIN_FORM_KEY)
 
+        # Successful login should not clear IP lock
+        self._login(username=VALID_USERNAME, password=VALID_PASSWORD)
+
+        # We should still be locked out for the locked
+        # username using the same IP
+        response = self._login(username=username)
+        self.assertContains(response, self.LOCKED_MESSAGE)
+
         # We shouldn't get a lockout message when attempting to use a
         # different ip address
         ip = "74.125.239.60"

--- a/defender/utils.py
+++ b/defender/utils.py
@@ -283,7 +283,10 @@ def reset_failed_attempts(ip_address=None, username=None):
     """
     pipe = REDIS_SERVER.pipeline()
 
-    unblock_ip(ip_address, pipe=pipe)
+    # Because IP is shared, a reset should never clear an IP block
+    # when using IP/username as block
+    if not config.LOCKOUT_BY_IP_USERNAME:
+        unblock_ip(ip_address, pipe=pipe)
     unblock_username(username, pipe=pipe)
 
     pipe.execute()


### PR DESCRIPTION
patching https://github.com/jazzband/django-defender/issues/188, first committing changes to test that should fail, then will squash with fixing changes