### PR TITLE
Define AppConfig.default_auto_field to match the initial migration

### DIFF
--- a/defender/apps.py
+++ b/defender/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class DefenderAppConfig(AppConfig):
+    name = "defender"
+    default_auto_field = "django.db.models.AutoField"


### PR DESCRIPTION
This patch removes a warning but also prevents creating migrations in projects
where DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField".

This is a fix for https://github.com/jazzband/django-defender/issues/195