### PR TITLE
Update `exampleapp` to use new routing/templates settings

### DIFF
--- a/exampleapp/settings.py
+++ b/exampleapp/settings.py
@@ -28,6 +28,7 @@ MIDDLEWARE = (
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "defender.middleware.FailedLoginMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware"
 )
 
 ROOT_URLCONF = "exampleapp.urls"
@@ -80,3 +81,18 @@ app.config_from_object("django.conf:settings")
 app.autodiscover_tasks(lambda: INSTALLED_APPS)
 
 DEBUG = True
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
+]

--- a/exampleapp/urls.py
+++ b/exampleapp/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include
+from django.urls import include, re_path
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
@@ -6,11 +6,10 @@ from django.conf.urls.static import static
 
 admin.autodiscover()
 
-urlpatterns = patterns(
-    "",
-    (r"^admin/", include(admin.site.urls)),
-    (r"^admin/defender/", include("defender.urls")),
-)
+urlpatterns = [
+    re_path(r"^admin/", admin.site.urls),
+    re_path(r"^admin/defender/", include("defender.urls")),
+]
 
 
 urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
The exampleapp is still running deprecated code.