### PR TITLE
Fix password quotation docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -367,7 +367,7 @@ These should be defined in your ``settings.py`` file.
 * ``DEFENDER_REDIS_URL``\ : String: the redis url for defender.
   [Default: ``redis://localhost:6379/0``\ ]
   (Example with password: ``redis://:mypassword@localhost:6379/0``\ )
-* ``DEFENDER_REDIS_PASSWORD_QUOTE``\ : Boolean: if special character in redis password(like '@'), we can quote password(urllib.quote_plus("password!@#")), and set to True.
+* ``DEFENDER_REDIS_PASSWORD_QUOTE``\ : Boolean: if special character in redis password (like '@'), we can quote password ``urllib.parse.quote("password!@#")``, and set to True.
   [Default: ``False``\ ]
 * ``DEFENDER_REDIS_NAME``\ : String: the name of your cache client on the CACHES django setting. If set, ``DEFENDER_REDIS_URL`` will be ignored.
   [Default: ``None``\ ]


### PR DESCRIPTION
- The `quote` function is inside [`urllib.parse`](https://docs.python.org/3/library/urllib.parse.html) module, not it's parent `urllib` module.
- Use [`quote`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote) instead of [`quote_plus`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote_plus) since the parsing in [`defender.connections`](https://github.com/jazzband/django-defender/blob/b90e545d20eee3e04e67339a2081859252acbc41/defender/connection.py#L71) use [`unquote`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.unquote) instead of [`unquote_plus`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.unquote_plus).