### PR TITLE
Fix admin url example docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -169,7 +169,7 @@ following to your ``urls.py``
 .. code-block:: python
 
    urlpatterns = [
-       path('admin/', include(admin.site.urls)), # normal admin
+       path('admin/', admin.site.urls), # normal admin
        path('admin/defender/', include('defender.urls')), # defender admin
        # your own patterns follow...
    ]


### PR DESCRIPTION
The correct way to add django admin urls is without using `include()` https://docs.djangoproject.com/en/4.0/ref/contrib/admin/#hooking-adminsite-to-urlconf