### PR TITLE
Pinpoint PyPy version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.8']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.8-v7.3.7']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This is a workaround due to [SQLite version bug on PyPy v7.3.8](https://foss.heptapod.net/pypy/pypy/-/issues/3690).

Reference:https://github.com/actions/setup-python/issues/339#issuecomment-1050840703