### PR TITLE
Revert PyPy version pinpoint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.8-v7.3.7']
+        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.8']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Revert #206.

PyPy 7.3.9 has now been [released](https://doc.pypy.org/en/latest/release-v7.3.9.html) with the updated SQLite version.