### PR TITLE
Changing order of defender urls in documentation and exampleapp/urls.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -169,8 +169,8 @@ following to your ``urls.py``
 .. code-block:: python
 
    urlpatterns = [
-       path('admin/', admin.site.urls), # normal admin
        path('admin/defender/', include('defender.urls')), # defender admin
+       path('admin/', admin.site.urls), # normal admin
        # your own patterns follow...
    ]
 

--- a/exampleapp/urls.py
+++ b/exampleapp/urls.py
@@ -7,8 +7,8 @@ from django.conf.urls.static import static
 admin.autodiscover()
 
 urlpatterns = [
-    re_path(r"^admin/", admin.site.urls),
     re_path(r"^admin/defender/", include("defender.urls")),
+    re_path(r"^admin/", admin.site.urls),
 ]
 
 


### PR DESCRIPTION
if  `/admin/` comes before `/admin/defender/` then `/admin/defender/blocks/` url will give 404