### PR TITLE
Bugfix strip_keys

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -169,8 +169,8 @@ following to your ``urls.py``
 .. code-block:: python
 
    urlpatterns = [
-       path('admin/', admin.site.urls), # normal admin
        path('admin/defender/', include('defender.urls')), # defender admin
+       path('admin/', admin.site.urls), # normal admin
        # your own patterns follow...
    ]
 

--- a/defender/tests.py
+++ b/defender/tests.py
@@ -1099,3 +1099,10 @@ class TestUtils(DefenderTestCase):
         req = HttpRequest()
         req.META["HTTP_X_FORWARDED_FOR"] = "[2001:db8::1]:123456"
         self.assertEqual(utils.get_ip(req), "2001:db8::1")
+
+    def test_remove_prefix(self):
+        """ test the remove_prefix() method """
+        self.assertEqual(utils.remove_prefix(
+            "defender:blocked:ip:192.168.24.24", "defender:blocked:"), "ip:192.168.24.24")
+        self.assertEqual(utils.remove_prefix(
+            "defender:blocked:username:johndoe", "defender:blocked:"), "username:johndoe")

--- a/defender/tests.py
+++ b/defender/tests.py
@@ -1106,3 +1106,6 @@ class TestUtils(DefenderTestCase):
             "defender:blocked:ip:192.168.24.24", "defender:blocked:"), "ip:192.168.24.24")
         self.assertEqual(utils.remove_prefix(
             "defender:blocked:username:johndoe", "defender:blocked:"), "username:johndoe")
+        self.assertEqual(utils.remove_prefix(
+            "defender:blocked:username:johndoe", "blocked:username:"),
+            "defender:blocked:username:johndoe")

--- a/defender/utils.py
+++ b/defender/utils.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import sys
 
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect
@@ -126,20 +127,42 @@ def get_username_blocked_cache_key(username):
     )
 
 
+def remove_prefix(string, prefix):
+
+    # backwards compatibility for str.removeprefix for python < 3.9
+    if sys.version_info < (3, 9):
+        if string.startswith(prefix):
+            return string[len(prefix) :]
+        return string
+
+    return string.removeprefix(prefix)
+
+
 def strip_keys(key_list):
     """ Given a list of keys, remove the prefix and remove just
     the data we care about.
 
     for example:
 
-        ['defender:blocked:ip:ken', 'defender:blocked:ip:joffrey']
+        [
+            'defender:blocked:ip:192.168.24.24',
+            'defender:blocked:ip:::ffff:192.168.24.24',
+            'defender:blocked:username:joffrey'
+        ]
 
     would result in:
 
-        ['ken', 'joffrey']
-
+        [
+            '192.168.24.24',
+            '::ffff:192.168.24.24',
+            'joffrey'
+        ]
     """
-    return [key.split(":")[-1] for key in key_list]
+    return [
+        # key.removeprefix(f"{config.CACHE_PREFIX}:blocked:").partition(":")[2]
+        remove_prefix(key, f"{config.CACHE_PREFIX}:blocked:").partition(":")[2]
+        for key in key_list
+    ]
 
 
 def get_blocked_ips():

--- a/defender/utils.py
+++ b/defender/utils.py
@@ -128,14 +128,10 @@ def get_username_blocked_cache_key(username):
 
 
 def remove_prefix(string, prefix):
+    if string.startswith(prefix):
+        return string[len(prefix):]
+    return string
 
-    # backwards compatibility for str.removeprefix for python < 3.9
-    if sys.version_info < (3, 9):
-        if string.startswith(prefix):
-            return string[len(prefix) :]
-        return string
-
-    return string.removeprefix(prefix)
 
 
 def strip_keys(key_list):

--- a/exampleapp/urls.py
+++ b/exampleapp/urls.py
@@ -7,8 +7,8 @@ from django.conf.urls.static import static
 admin.autodiscover()
 
 urlpatterns = [
-    re_path(r"^admin/", admin.site.urls),
     re_path(r"^admin/defender/", include("defender.urls")),
+    re_path(r"^admin/", admin.site.urls),
 ]
 
 


### PR DESCRIPTION
When the IP is an ipv6, like `::ffff:192.168.24.24`, `strip_keys` method gives an incorrect response.