### PR TITLE
Fix `watch_login` with custom username

### DIFF
--- a/defender/decorators.py
+++ b/defender/decorators.py
@@ -18,8 +18,10 @@ def watch_login(status_code=302, msg="", get_username=utils.get_username_from_re
             # if the request is currently under lockout, do not proceed to the
             # login function, go directly to lockout url, do not pass go,
             # do not collect messages about this login attempt
-            if utils.is_already_locked(request):
-                return utils.lockout_response(request)
+            username = get_username(request)
+
+            if utils.is_already_locked(request, username=username):
+                return utils.lockout_response(request, username=username)
 
             # call the login function
             response = func(request, *args, **kwargs)
@@ -44,13 +46,13 @@ def watch_login(status_code=302, msg="", get_username=utils.get_username_from_re
                 # ideally make this background task, but to keep simple,
                 # keeping it inline for now.
                 utils.add_login_attempt_to_db(
-                    request, not login_unsuccessful, get_username
+                    request, not login_unsuccessful, username=username
                 )
 
-                if utils.check_request(request, login_unsuccessful, get_username):
+                if utils.check_request(request, login_unsuccessful, username=username):
                     return response
 
-                return utils.lockout_response(request)
+                return utils.lockout_response(request, username=username)
 
             return response
 

--- a/defender/utils.py
+++ b/defender/utils.py
@@ -63,7 +63,7 @@ def strip_port_number(ip_address_string):
 
     """
     If it's not a valid IP address, we prefer to return
-    the string as-is instead of returning a potentially 
+    the string as-is instead of returning a potentially
     corrupted string:
     """
     if is_valid_ip(ip_address):
@@ -360,10 +360,9 @@ def reset_failed_attempts(ip_address=None, username=None):
     pipe.execute()
 
 
-def lockout_response(request):
+def lockout_response(request, username):
     """ if we are locked out, here is the response """
     ip_address = get_ip(request)
-    username = get_username_from_request(request)
     if config.LOCKOUT_TEMPLATE:
         cooloff_time = get_lockout_cooloff_time(ip_address=ip_address, username=username)
         context = {


### PR DESCRIPTION
Previously using of custom `get_username` function with disabled IP lockout caused unhandled exception
`Exception("Invalid state requested")`