### PR TITLE
Update DEFENDER_REDIS_NAME documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -381,7 +381,7 @@ These should be defined in your ``settings.py`` file.
   (Example with password: ``redis://:mypassword@localhost:6379/0``\ )
 * ``DEFENDER_REDIS_PASSWORD_QUOTE``\ : Boolean: if special character in redis password (like '@'), we can quote password ``urllib.parse.quote("password!@#")``, and set to True.
   [Default: ``False``\ ]
-* ``DEFENDER_REDIS_NAME``\ : String: the name of your cache client on the CACHES django setting. If set, ``DEFENDER_REDIS_URL`` will be ignored.
+* ``DEFENDER_REDIS_NAME``\ : String: the name of the cache from ``CACHES`` in your Django settings (e.g. ``"default"``). If set, ``DEFENDER_REDIS_URL`` will be ignored.
   [Default: ``None``\ ]
 * ``DEFENDER_STORE_ACCESS_ATTEMPTS``\ : Boolean: If you want to store the login
   attempt to the database, set to True. If False, it is not saved


### PR DESCRIPTION
Suggesting that this uses the name of the _client_ is misleading and confusing, as that would be the name of a backend (e.g. RedisCache). The referencing code uses DEFENDER_REDIS_NAME to look up the named cache from `CACHES` instead.