### PR TITLE
Updated app_index.html

### DIFF
--- a/defender/templates/admin/defender/app_index.html
+++ b/defender/templates/admin/defender/app_index.html
@@ -1,19 +1,4 @@
-{% extends "admin/index.html" %}
-{% load i18n %}
-
-{% if not is_popup %}
-{% block breadcrumbs %}
-<div class="breadcrumbs">
-    <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
-    &rsaquo;
-    {% for app in app_list %}
-    {{ app.name }}
-    {% endfor %}
-</div>
-{% endblock %}
-{% endif %}
-
-{% block sidebar %}{% endblock %}
+{% extends "admin/app_index.html" %}
 
 {% block content %}
 {{ block.super }}


### PR DESCRIPTION
[django-defender's `app_index.html` template](https://github.com/jazzband/django-defender/blob/v0.9.7/defender/templates/admin/defender/app_index.html) is based on some old version of Django's `app_index.html` template. It's just like [the one used in many versions of Django prior to 3.1](https://github.com/django/django/blob/3.0.14/django/contrib/admin/templates/admin/app_index.html) except that its indentation is different and it doesn't contain `{% block bodyclass %}{{ block.super }} app-{{ app_label }}{% endblock %}`. This has worked fine for anyone not relying on the `bodyclass` block being present. However, as of Django 4.2.1, the breadcrumbs are handled differently (compare [Django 4.2's `app_index.html` template](https://github.com/django/django/blob/4.2/django/contrib/admin/templates/admin/app_index.html) with [Django 4.2.1's `app_index.html` template](https://github.com/django/django/blob/4.2.1/django/contrib/admin/templates/admin/app_index.html)). Rather than trying to keep django-defender's `app_index.html` template in sync with Django's, it's probably better to just extend Django's.