### PR TITLE
added feature to send email once the user is blocked based on username

### DIFF
--- a/defender/config.py
+++ b/defender/config.py
@@ -93,6 +93,12 @@ LOCKOUT_URL = get_setting("DEFENDER_LOCKOUT_URL")
 
 USE_CELERY = get_setting("DEFENDER_USE_CELERY", False)
 
+EMAIL_USER_ON_ACCOUNT_LOCKED = get_setting("DEFENDER_EMAIL_USER_ON_ACCOUNT_LOCKED", False)
+# A 'user' instance is passed as context to lockout email template
+LOCKOUT_EMAIL_TEMPLATE_PATH = get_setting("DEFENDER_LOCKOUT_EMAIL_TEMPLATE_PATH", "defender/lockout_email.html")
+
+DEFAULT_FROM_EMAIL = get_setting("DEFENDER_DEFAULT_FROM_EMAIL")
+
 STORE_ACCESS_ATTEMPTS = get_setting("DEFENDER_STORE_ACCESS_ATTEMPTS", True)
 
 # Used by the management command to decide how long to keep access attempt

--- a/defender/templates/defender/lockout_email.html
+++ b/defender/templates/defender/lockout_email.html
@@ -1,0 +1,6 @@
+Hi {{ user.username }},
+<br>
+<br>
+Your account has been locked out due to too many failed login attempts. 
+Please contact the administrator to unlock your account.
+<br>


### PR DESCRIPTION
## Implementation Details

The implementation checks for a new setting, `DEFENDER_EMAIL_USER_ON_ACCOUNT_LOCKED`, to determine if an email should be sent when an account is locked. by default it's False.

An email template `defender/lockout_email.html` is provided, which can be overridden by setting `DEFENDER_LOCKOUT_EMAIL_TEMPLATE_PATH` in the project's settings. The email is sent using Django's built-in `send_mail` function, assuming that the email backend configured for the project.
